### PR TITLE
Add previously_new_record? to Active Record models

### DIFF
--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -401,6 +401,7 @@ module ActiveRecord
       _run_initialize_callbacks
 
       @new_record               = true
+      @previously_new_record    = false
       @destroyed                = false
       @_start_transaction_state = nil
       @transaction_state        = nil
@@ -570,6 +571,7 @@ module ActiveRecord
       def init_internals
         @primary_key              = self.class.primary_key
         @readonly                 = false
+        @previously_new_record    = false
         @destroyed                = false
         @marked_for_destruction   = false
         @destroyed_by_association = nil

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -428,6 +428,14 @@ module ActiveRecord
       @new_record
     end
 
+    # Returns true if this object was just created -- that is, prior to the last
+    # save, the object didn't exist in the database and new_record? would have
+    # returned true.
+    def previously_new_record?
+      sync_with_transaction_state
+      @previously_new_record
+    end
+
     # Returns true if this object has been destroyed, otherwise returns false.
     def destroyed?
       sync_with_transaction_state if @transaction_state&.finalized?
@@ -811,6 +819,7 @@ module ActiveRecord
 
       @attributes = fresh_object.instance_variable_get("@attributes")
       @new_record = false
+      @previously_new_record = false
       self
     end
 
@@ -915,6 +924,8 @@ module ActiveRecord
         @_trigger_update_callback = affected_rows == 1
       end
 
+      @previously_new_record = false
+
       yield(self) if block_given?
 
       affected_rows
@@ -932,6 +943,7 @@ module ActiveRecord
       self.id ||= new_id if @primary_key
 
       @new_record = false
+      @previously_new_record = true
 
       yield(self) if block_given?
 

--- a/activerecord/lib/active_record/transactions.rb
+++ b/activerecord/lib/active_record/transactions.rb
@@ -391,6 +391,7 @@ module ActiveRecord
         @_start_transaction_state ||= {
           id: id,
           new_record: @new_record,
+          previously_new_record: @previously_new_record,
           destroyed: @destroyed,
           attributes: @attributes,
           frozen?: frozen?,
@@ -423,6 +424,7 @@ module ActiveRecord
         if restore_state = @_start_transaction_state
           if force_restore_state || restore_state[:level] <= 1
             @new_record = restore_state[:new_record]
+            @previously_new_record = restore_state[:previously_new_record]
             @destroyed  = restore_state[:destroyed]
             @attributes = restore_state[:attributes].map do |attr|
               value = @attributes.fetch_value(attr.name)

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -729,6 +729,12 @@ class BasicsTest < ActiveRecord::TestCase
     assert_equal true, Topic.find(1).persisted?
   end
 
+  def test_previously_new_record_returns_boolean
+    assert_equal false, Topic.new.previously_new_record?
+    assert_equal true, Topic.create.previously_new_record?
+    assert_equal false, Topic.find(1).previously_new_record?
+  end
+
   def test_dup
     topic = Topic.find(1)
     duped_topic = nil

--- a/activerecord/test/cases/clone_test.rb
+++ b/activerecord/test/cases/clone_test.rb
@@ -13,6 +13,7 @@ module ActiveRecord
       assert topic.persisted?, "topic persisted"
       assert cloned.persisted?, "topic persisted"
       assert_not cloned.new_record?, "topic is not new"
+      assert_not cloned.previously_new_record?, "topic was not previously new"
     end
 
     def test_stays_frozen

--- a/activerecord/test/cases/dup_test.rb
+++ b/activerecord/test/cases/dup_test.rb
@@ -36,6 +36,13 @@ module ActiveRecord
       assert duped.new_record?, "topic is new"
     end
 
+    def test_dup_not_previously_new_record
+      topic = Topic.first
+      duped = topic.dup
+
+      assert_not duped.previously_new_record?, "should not be a previously new record"
+    end
+
     def test_dup_not_destroyed
       topic = Topic.first
       topic.destroy

--- a/activerecord/test/cases/transactions_test.rb
+++ b/activerecord/test/cases/transactions_test.rb
@@ -782,6 +782,18 @@ class TransactionTest < ActiveRecord::TestCase
     assert_not_predicate topic, :new_record?
   end
 
+  def test_restore_previously_new_record_after_double_save
+    topic = Topic.create!
+
+    Topic.transaction do
+      topic.save!
+      topic.save!
+      raise ActiveRecord::Rollback
+    end
+
+    assert_predicate topic, :previously_new_record?
+  end
+
   def test_restore_id_after_rollback
     topic = Topic.new
 


### PR DESCRIPTION
### Summary

Adds a `previously_new_record?` method to Active Record models, returning true if prior to the last save the model was a new record. The name `previously_new_record?` was chosen to mirror methods like `x_previously_changed?`.

Take a table with a `status` column with default value `published`:
```ruby
create_table :examples do |table|
  table.string :status, default: 'published'
end
```
If we want to indicate whether it's the first time the record has been saved with the status `published`, we can't use `status_previously_changed?`, as it rightly doesn't register a change from the default. We can check `id_previously_changed?` instead, but this both isn't as descriptive, and can technically be triggered in other situations. `record.update id: 999, status: 'published'` is legal if unwise code.

A specific `status_previously_changed?` method is both clearer and more correct.
```ruby
class Example < ActiveRecord::Base
  after_save_commit :broadcast_publication, if: :previously_published?

  # Implementation without new previously_new_record? method
  def previously_published?
    status == "published" && (status_previously_changed? || id_previously_changed?)
  end

  # Implementation with
  def previously_published?
    status == "published" && (status_previously_changed? || previously_new_record?)
  end
end
```
### Other Information

We're using this right now at Basecamp, and @dhh asked me to bring it over to rails.

For the implementation I've tried to mirror existing similar code and tests as much as possible, but I'm not deeply familiar with the way things are done so very happy to change it to suit.