### PR TITLE
Reconciling differences between this and Basecamp's fork of Action Text

### DIFF
--- a/actiontext/actiontext.gemspec
+++ b/actiontext/actiontext.gemspec
@@ -39,4 +39,5 @@ Gem::Specification.new do |s|
 
   s.add_dependency "nokogiri", ">= 1.8.5"
   s.add_dependency "globalid", ">= 0.6.0"
+  s.add_dependency "okra", ">= 1.0.0"
 end

--- a/actiontext/app/helpers/action_text/content_helper.rb
+++ b/actiontext/app/helpers/action_text/content_helper.rb
@@ -4,7 +4,7 @@ require "rails-html-sanitizer"
 
 module ActionText
   module ContentHelper
-    mattr_accessor(:sanitizer) { Rails::Html::Sanitizer.safe_list_sanitizer.new }
+    mattr_accessor(:sanitizer) { scrubber.present? ? Rails::Html::Sanitizer.safe_list_sanitizer.new : Okra::HTML::Sanitizer.new }
     mattr_accessor(:allowed_tags) { sanitizer.class.allowed_tags + [ ActionText::Attachment.tag_name, "figure", "figcaption" ] }
     mattr_accessor(:allowed_attributes) { sanitizer.class.allowed_attributes + ActionText::Attachment::ATTRIBUTES }
     mattr_accessor(:scrubber)
@@ -15,38 +15,40 @@ module ActionText
     end
 
     def sanitize_action_text_content(content)
-      sanitizer.sanitize(content.to_html, tags: allowed_tags, attributes: allowed_attributes, scrubber: scrubber).html_safe
+      content = content.to_html unless sanitizer.try(:accepts_nodes?)
+      sanitizer.sanitize(content, tags: allowed_tags, attributes: allowed_attributes, scrubber: scrubber).html_safe
     end
 
     def render_action_text_attachments(content)
       content.render_attachments do |attachment|
         unless attachment.in?(content.gallery_attachments)
-          attachment.node.tap do |node|
-            node.inner_html = render_action_text_attachment attachment, locals: { in_gallery: false }
-          end
+          node = attachment.node
+          html = render_action_text_attachment attachment, locals: { in_gallery: false }
+          Okra::HTML.element_node(node.name, node.attributes, html)
         end
       end.render_attachment_galleries do |attachment_gallery|
         render(layout: attachment_gallery, object: attachment_gallery) do
-          attachment_gallery.attachments.map do |attachment|
-            attachment.node.inner_html = render_action_text_attachment attachment, locals: { in_gallery: true }
-            attachment.to_html
-          end.join.html_safe
+          Okra::HTML.fragment_node(*attachment_gallery.attachments.map do |attachment|
+            node = attachment.node
+            html = render_action_text_attachment attachment, locals: { in_gallery: false }
+            Okra::HTML.element_node(node.name, node.attributes, html)
+          end).to_html.html_safe
         end.chomp
       end
     end
+  end
 
-    def render_action_text_attachment(attachment, locals: {}) # :nodoc:
-      options = { locals: locals, object: attachment, partial: attachment }
+  def render_action_text_attachment(attachment, locals: {}) # :nodoc:
+    options = { locals: locals, object: attachment, partial: attachment }
 
-      if attachment.respond_to?(:to_attachable_partial_path)
-        options[:partial] = attachment.to_attachable_partial_path
-      end
-
-      if attachment.respond_to?(:model_name)
-        options[:as] = attachment.model_name.element
-      end
-
-      render(**options).chomp
+    if attachment.respond_to?(:to_attachable_partial_path)
+      options[:partial] = attachment.to_attachable_partial_path
     end
+
+    if attachment.respond_to?(:model_name)
+      options[:as] = attachment.model_name.element
+    end
+
+    render(**options).chomp
   end
 end

--- a/actiontext/app/helpers/action_text/tag_helper.rb
+++ b/actiontext/app/helpers/action_text/tag_helper.rb
@@ -50,7 +50,12 @@ module ActionView::Helpers
       options = @options.stringify_keys
       add_default_name_and_id(options)
       options["input"] ||= dom_id(object, [options["id"], :trix_input].compact.join("_")) if object
-      @template_object.rich_text_area_tag(options.delete("name"), options.fetch("value") { value }, options.except("value"))
+      prepared_value = prepare_value(options.fetch("value") { value })
+      @template_object.rich_text_area_tag(options.delete("name"), prepared_value, options.except("value"))
+    end
+
+    def prepare_value(value)
+      value&.body.try(:to_trix_html)
     end
   end
 

--- a/actiontext/app/models/action_text/rich_text.rb
+++ b/actiontext/app/models/action_text/rich_text.rb
@@ -10,6 +10,7 @@ module ActionText
 
     serialize :body, ActionText::Content
     delegate :to_s, :nil?, to: :body
+    delegate_missing_to :body
 
     belongs_to :record, polymorphic: true, touch: true
     has_many_attached :embeds

--- a/actiontext/app/views/action_text/attachables/_content_attachment.html.erb
+++ b/actiontext/app/views/action_text/attachables/_content_attachment.html.erb
@@ -1,0 +1,3 @@
+<figure class="attachment attachment--content">
+  <%= content_attachment.attachable %>
+</figure>

--- a/actiontext/app/views/action_text/contents/_content.html.erb
+++ b/actiontext/app/views/action_text/contents/_content.html.erb
@@ -1,1 +1,1 @@
-<%= render_action_text_content(content) %>
+<%= render_action_text_content(content) -%>

--- a/actiontext/lib/action_text.rb
+++ b/actiontext/lib/action_text.rb
@@ -3,7 +3,7 @@
 require "active_support"
 require "active_support/rails"
 
-require "nokogiri"
+require "okra"
 
 module ActionText
   extend ActiveSupport::Autoload

--- a/actiontext/lib/action_text/attachables/content_attachment.rb
+++ b/actiontext/lib/action_text/attachables/content_attachment.rb
@@ -6,33 +6,35 @@ module ActionText
       include ActiveModel::Model
 
       def self.from_node(node)
-        if node["content-type"]
-          if matches = node["content-type"].match(/vnd\.rubyonrails\.(.+)\.html/)
-            attachment = new(name: matches[1])
-            attachment if attachment.valid?
-          end
-        end
+        attachment = new(content_type: node["content-type"], content: node["content"])
+        attachment if attachment.valid?
       end
 
-      attr_accessor :name
-      validates_inclusion_of :name, in: %w( horizontal-rule )
+      attr_accessor :content_type, :content
+
+      validates_format_of :content_type, with: /html/
+      validates_presence_of :content
 
       def attachable_plain_text_representation(caption)
-        case name
-        when "horizontal-rule"
-          " ┄ "
-        else
-          " "
-        end
+        content_instance.fragment.source
+      end
+
+      def to_html
+        @to_html ||= content_instance.render
+      end
+
+      def to_s
+        to_html
       end
 
       def to_partial_path
         "action_text/attachables/content_attachment"
       end
 
-      def to_trix_content_attachment_partial_path
-        "action_text/attachables/content_attachments/#{name.underscore}"
-      end
+      private
+        def content_instance
+          @content_instance ||= ActionText::Content.new(content)
+        end
     end
   end
 end

--- a/actiontext/lib/action_text/attachables/remote_image.rb
+++ b/actiontext/lib/action_text/attachables/remote_image.rb
@@ -8,7 +8,7 @@ module ActionText
       class << self
         def from_node(node)
           if node["url"] && content_type_is_image?(node["content-type"])
-            new(attributes_from_node(node))
+            new(**attributes_from_node(node))
           end
         end
 
@@ -21,17 +21,19 @@ module ActionText
             { url: node["url"],
               content_type: node["content-type"],
               width: node["width"],
-              height: node["height"] }
+              height: node["height"],
+              data: Attachment.data_attributes_from_node(node) }
           end
       end
 
-      attr_reader :url, :content_type, :width, :height
+      attr_reader :url, :content_type, :width, :height, :data
 
-      def initialize(attributes = {})
-        @url = attributes[:url]
-        @content_type = attributes[:content_type]
-        @width = attributes[:width]
-        @height = attributes[:height]
+      def initialize(url:, content_type:, width:, height:, data: {})
+        @url = url
+        @content_type = content_type
+        @width = width
+        @height = height
+        @data = data.stringify_keys.freeze
       end
 
       def attachable_plain_text_representation(caption)

--- a/actiontext/lib/action_text/attachments/minification.rb
+++ b/actiontext/lib/action_text/attachments/minification.rb
@@ -7,8 +7,26 @@ module ActionText
 
       class_methods do
         def fragment_by_minifying_attachments(content)
-          Fragment.wrap(content).replace(ActionText::Attachment.tag_name) do |node|
-            node.tap { |n| n.inner_html = "" }
+          Fragment.wrap(content).replace(Attachment::SELECTOR) do |node|
+            if source_content = node["content"].presence
+              value = fragment_by_minifying_attachments(source_content).to_s
+              if source_content == value && node.child_nodes.empty?
+                node
+              else
+                Okra::HTML.element_node(node.name, node.attributes.map do |attribute|
+                  key, _ = attribute
+                  if key == "content"
+                    [key, value]
+                  else
+                    attribute
+                  end
+                end, [])
+              end
+            elsif node.child_nodes.empty?
+              node
+            else
+              Okra::HTML.element_node(node.name, node.attributes, [])
+            end
           end
         end
       end

--- a/actiontext/lib/action_text/attachments/trix_conversion.rb
+++ b/actiontext/lib/action_text/attachments/trix_conversion.rb
@@ -27,8 +27,11 @@ module ActionText
 
       private
         def trix_attachment_content
+          return if attachable.try(:content_attachable?) == false
           if partial_path = attachable.try(:to_trix_content_attachment_partial_path)
-            ActionText::Content.render(partial: partial_path, formats: :html, object: self, as: model_name.element)
+            ActionText.renderer.render(partial: partial_path, object: self, as: model_name.element)
+          else
+            attachable.try(:to_html)
           end
         end
     end

--- a/actiontext/lib/action_text/html_conversion.rb
+++ b/actiontext/lib/action_text/html_conversion.rb
@@ -5,20 +5,18 @@ module ActionText
     extend self
 
     def node_to_html(node)
-      node.to_html(save_with: Nokogiri::XML::Node::SaveOptions::AS_HTML)
+      node.to_html
     end
 
     def fragment_for_html(html)
-      document.fragment(html)
+      Okra::HTML.parse_fragment(html)
     end
 
-    def create_element(tag_name, attributes = {})
-      document.create_element(tag_name, attributes)
+    def create_element(tag_name, attributes = {}, child_nodes = [])
+      Okra::HTML.element_node(tag_name, attributes.map do |name, value|
+        string_value = attributes[name].to_s
+        string_value.empty? ? [name.to_s] : [name.to_s, string_value]
+      end, child_nodes)
     end
-
-    private
-      def document
-        Nokogiri::HTML::Document.new.tap { |doc| doc.encoding = "UTF-8" }
-      end
   end
 end

--- a/actiontext/lib/action_text/trix_attachment.rb
+++ b/actiontext/lib/action_text/trix_attachment.rb
@@ -3,7 +3,7 @@
 module ActionText
   class TrixAttachment
     TAG_NAME = "figure"
-    SELECTOR = "[data-trix-attachment]"
+    SELECTOR = ->(node) { node["data-trix-attachment"] }
 
     COMPOSED_ATTRIBUTES = %w( caption presentation )
     ATTRIBUTES = %w( sgid contentType url href filename filesize width height previewable content ) + COMPOSED_ATTRIBUTES
@@ -22,9 +22,10 @@ module ActionText
         trix_attachment_attributes = attributes.except(*COMPOSED_ATTRIBUTES)
         trix_attributes = attributes.slice(*COMPOSED_ATTRIBUTES)
 
-        node = ActionText::HtmlConversion.create_element(TAG_NAME)
-        node["data-trix-attachment"] = JSON.generate(trix_attachment_attributes)
-        node["data-trix-attributes"] = JSON.generate(trix_attributes) if trix_attributes.any?
+        node_attributes = {}
+        node_attributes["data-trix-attachment"] = JSON.generate(trix_attachment_attributes)
+        node_attributes["data-trix-attributes"] = JSON.generate(trix_attributes) if trix_attributes.any?
+        node = ActionText::HtmlConversion.create_element(TAG_NAME, node_attributes)
 
         new(node)
       end
@@ -74,7 +75,9 @@ module ActionText
       end
 
       def read_json_object_attribute(name)
-        read_json_attribute(name) || {}
+        read_json_attribute(name).then do |json_object_attribute|
+          json_object_attribute.is_a?(Hash) ? json_object_attribute : {}
+        end
       end
 
       def read_json_attribute(name)


### PR DESCRIPTION
Primarily introducing the use of Okra instead of Nokogiri to manage the querying and rewriting of HTML (and now CSS, too).